### PR TITLE
autocorrection of pip_urls

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,9 @@ Changelog
 1.0.0a9 (unreleased)
 --------------------
 
-- Nothing changed yet.
-
+- Added autocorrection for pip urls, so that github or gitlab urls can be used as copied
+  in sources.ini .
+  [zworkb]
 
 1.0.0a8 (2021-11-30)
 --------------------

--- a/mxdev.py
+++ b/mxdev.py
@@ -195,9 +195,7 @@ def fetch(packages) -> None:
         logger.info(f"Fetch or update {name}")
         package: dict = packages[name]
         repo_dir: str = os.path.abspath(f"{package['target']}/{name}")
-        pip_url: str = autocorrect_pip_url(
-            f"{package['url']}@{package['branch']}"
-        )
+        pip_url: str = autocorrect_pip_url(f"{package['url']}@{package['branch']}")
         logger.debug(f"pip_url={pip_url} -> repo_dir={repo_dir}")
         repo = create_repo_from_pip_url(pip_url=pip_url, repo_dir=repo_dir)
         repo.update_repo()


### PR DESCRIPTION
automatically prepend the necessary prefix, so you dont have to think anymore when copy/passing gitlab and guthub urls