### PR TITLE
Support environment variable GIT_CLONE_DEPTH.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## 4.0.4 (unreleased)
 
+- Support environment variable `GIT_CLONE_DEPTH` for setting a default git depth for all checkouts.  Useful for CI.
+  [maurits]
+
 - Fix #47: Do not add packages with capital names uncommented at the bottom ignore list when checked out.
   [petschki]
 

--- a/README.md
+++ b/README.md
@@ -254,6 +254,13 @@ True by default, unless `default-use` in the general settings is false.
 When false, the source is not checked out,
 and the version for this package is not overridden.
 
+#### `depth`
+
+For `git` only.
+This is used to set the git clone depth.
+This is not set by default: you get a full clone.
+You can set environment variable `GIT_CLONE_DEPTH=1` to set a default git depth for all checkouts.  This is useful for CI.
+
 #### `submodules`
 
 There are 3 different options:

--- a/src/mxdev/vcs/git.py
+++ b/src/mxdev/vcs/git.py
@@ -9,6 +9,7 @@ import typing
 
 
 logger = common.logger
+GIT_CLONE_DEPTH = os.getenv("GIT_CLONE_DEPTH")
 
 
 class GitError(common.WCError):
@@ -151,8 +152,8 @@ class GitWorkingCopy(common.BaseWorkingCopy):
         update_git_submodules = self.source.get("submodules", kwargs["submodules"])
         if update_git_submodules == "recursive":
             args.append("--recurse-submodules")
-        if "depth" in self.source:
-            args.extend(["--depth", self.source["depth"]])
+        if "depth" in self.source or GIT_CLONE_DEPTH:
+            args.extend(["--depth", self.source.get("depth", GIT_CLONE_DEPTH)])
         if "branch" in self.source:
             args.extend(["-b", self.source["branch"]])
         args.extend([url, path])


### PR DESCRIPTION
This is used for setting a default git depth for all checkouts. Useful for CI.
A specific setting in a repo section still wins.

If accepted, a release would be very welcome, so I can use it in [Plone coredev](https://github.com/plone/buildout.coredev/pull/1020).