### PR TITLE
Add fixed install mode for production deployments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## 4.1.2 (unreleased)
 
+- Fix #54: Add `fixed` install mode for non-editable installations to support production and Docker deployments. The new `editable` mode replaces `direct` as the default (same behavior, clearer naming). The `direct` mode is now deprecated but still works with a warning. Install modes: `editable` (with `-e`, for development), `fixed` (without `-e`, for production/Docker), `skip` (clone only).
+  [jensens]
+
 - Fix #35: Add `smart-threading` configuration option to prevent overlapping credential prompts when using HTTPS URLs. When enabled (default), HTTPS packages are processed serially first to ensure clean credential prompts, then other packages are processed in parallel for speed. Can be disabled with `smart-threading = false` if you have credential helpers configured.
   [jensens]
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,12 +287,23 @@ main-package = -e .[test]
 url = git+https://github.com/org/package1.git
 branch = feature-branch
 extras = test
+install-mode = editable
 
 [package2]
 url = git+https://github.com/org/package2.git
 branch = main
+install-mode = fixed
+
+[package3]
+url = git+https://github.com/org/package3.git
 install-mode = skip
 ```
+
+**Install mode options:**
+- `editable` (default): Installs with `-e` prefix for development
+- `fixed`: Installs without `-e` prefix for production/Docker deployments
+- `skip`: Only clones, doesn't install
+- `direct`: Deprecated alias for `editable` (logs warning)
 
 **Using includes for shared configurations:**
 ```ini

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The **main section** must be called `[settings]`, even if kept empty.
 | `threads` | Number of parallel threads for fetching sources | `4` |
 | `smart-threading` | Process HTTPS packages serially to avoid overlapping credential prompts (see below) | `True` |
 | `offline` | Skip all VCS fetch operations (handy for offline work) | `False` |
-| `default-install-mode` | Default `install-mode` for packages: `direct` or `skip` | `direct` |
+| `default-install-mode` | Default `install-mode` for packages: `editable`, `fixed`, or `skip` (see below) | `editable` |
 | `default-update` | Default update behavior: `yes` or `no` | `yes` |
 | `default-use` | Default use behavior (when false, sources not checked out) | `True` |
 
@@ -220,7 +220,7 @@ For package sources, the section name is the package name: `[PACKAGENAME]`
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `install-mode` | `direct`: Install with `pip -e PACKAGEPATH`<br>`skip`: Only clone, don't install | `default-install-mode` |
+| `install-mode` | `editable`: Install with `-e` (development mode)<br>`fixed`: Install without `-e` (production/Docker)<br>`skip`: Only clone, don't install<br>⚠️ `direct` is deprecated, use `editable` | `default-install-mode` |
 | `use` | When `false`, source is not checked out and version not overridden | `default-use` |
 
 #### Git-Specific Options

--- a/src/mxdev/config.py
+++ b/src/mxdev/config.py
@@ -50,9 +50,22 @@ class Configuration:
         # overlapping credential prompts)
         settings.setdefault("smart-threading", "true")
 
-        mode = settings.get("default-install-mode", "direct")
-        if mode not in ["direct", "skip"]:
-            raise ValueError("default-install-mode must be one of 'direct' or 'skip'")
+        mode = settings.get("default-install-mode", "editable")
+
+        # Handle deprecated "direct" mode
+        if mode == "direct":
+            logger.warning(
+                "install-mode 'direct' is deprecated and will be removed in a future version. "
+                "Please use 'editable' instead."
+            )
+            mode = "editable"
+            settings["default-install-mode"] = "editable"
+
+        if mode not in ["editable", "fixed", "skip"]:
+            raise ValueError(
+                "default-install-mode must be one of 'editable', 'fixed', or 'skip' "
+                "('direct' is deprecated, use 'editable')"
+            )
 
         default_use = to_bool(settings.get("default-use", True))
         raw_overrides = settings.get("version-overrides", "").strip()
@@ -108,9 +121,21 @@ class Configuration:
             package.setdefault("path", os.path.join(package["target"], name))
             if not package.get("url"):
                 raise ValueError(f"Section {name} has no URL set!")
-            if package.get("install-mode") not in ["direct", "skip"]:
+
+            # Handle deprecated "direct" mode for per-package install-mode
+            pkg_mode = package.get("install-mode")
+            if pkg_mode == "direct":
+                logger.warning(
+                    f"install-mode 'direct' is deprecated and will be removed in a future version. "
+                    f"Please use 'editable' instead (package: {name})."
+                )
+                package["install-mode"] = "editable"
+                pkg_mode = "editable"
+
+            if pkg_mode not in ["editable", "fixed", "skip"]:
                 raise ValueError(
-                    f"install-mode in [{name}] must be one of 'direct' or 'skip'"
+                    f"install-mode in [{name}] must be one of 'editable', 'fixed', or 'skip' "
+                    f"('direct' is deprecated, use 'editable')"
                 )
 
             # repo_dir = os.path.abspath(f"{package['target']}/{name}")

--- a/src/mxdev/processing.py
+++ b/src/mxdev/processing.py
@@ -220,9 +220,13 @@ def write_dev_sources(fio, packages: typing.Dict[str, typing.Dict[str, typing.An
             continue
         extras = f"[{package['extras']}]" if package["extras"] else ""
         subdir = f"/{package['subdirectory']}" if package["subdirectory"] else ""
-        editable = f"""-e ./{package['target']}/{name}{subdir}{extras}\n"""
-        logger.debug(f"-> {editable.strip()}")
-        fio.write(editable)
+
+        # Add -e prefix only for 'editable' mode (not for 'fixed')
+        prefix = "-e " if package["install-mode"] == "editable" else ""
+        install_line = f"""{prefix}./{package['target']}/{name}{subdir}{extras}\n"""
+
+        logger.debug(f"-> {install_line.strip()}")
+        fio.write(install_line)
     fio.write("\n\n")
 
 

--- a/tests/data/config_samples/config_deprecated_direct.ini
+++ b/tests/data/config_samples/config_deprecated_direct.ini
@@ -1,0 +1,5 @@
+[settings]
+default-install-mode = direct
+
+[example.package]
+url = git+https://github.com/example/package.git

--- a/tests/data/config_samples/config_editable_mode.ini
+++ b/tests/data/config_samples/config_editable_mode.ini
@@ -1,0 +1,5 @@
+[settings]
+default-install-mode = editable
+
+[example.package]
+url = git+https://github.com/example/package.git

--- a/tests/data/config_samples/config_fixed_mode.ini
+++ b/tests/data/config_samples/config_fixed_mode.ini
@@ -1,0 +1,5 @@
+[settings]
+default-install-mode = fixed
+
+[example.package]
+url = git+https://github.com/example/package.git

--- a/tests/data/config_samples/config_package_direct.ini
+++ b/tests/data/config_samples/config_package_direct.ini
@@ -1,0 +1,6 @@
+[settings]
+default-install-mode = editable
+
+[example.package]
+url = git+https://github.com/example/package.git
+install-mode = direct


### PR DESCRIPTION
## Summary
Adds support for non-editable (fixed) installations to enable production and Docker deployments, addressing issue #54.

## Changes
- **New `fixed` install mode**: Installs packages without `-e` prefix for production use
- **New `editable` install mode**: Installs packages with `-e` prefix (replaces `direct` as default)
- **Deprecate `direct` mode**: Kept as backward-compatible alias for `editable` with deprecation warning
- **Keep `skip` mode**: Unchanged behavior

## Implementation Details
- Modified `config.py` to validate new modes and handle deprecation
- Modified `processing.py` to conditionally add `-e` prefix based on install mode
- Default install mode changed from `direct` to `editable` (same behavior, clearer naming)
- Deprecation warnings logged when `direct` mode is used (global or per-package)

## Documentation
- Updated README.md with new install mode options
- Updated CLAUDE.md with examples and explanations
- Added CHANGES.md entry for version 4.1.2

## Test Coverage
- Added 4 new test configuration files
- Added 4 new configuration tests for new modes and deprecation
- Added 2 new processing tests for fixed and mixed modes
- Updated 1 existing test for new default behavior
- All 172 tests passing ✓

## Test-Driven Development
This PR was implemented using TDD methodology:
1. ✅ Red phase: Wrote failing tests first
2. ✅ Green phase: Implemented code to pass tests
3. ✅ Verification: All tests pass

## Backward Compatibility
- Existing configurations using `direct` mode continue to work
- Deprecation warning logged to guide users to migrate to `editable`
- No breaking changes

Fixes #54